### PR TITLE
修复：server Caddy 路由配置，支持 admin 前端访问

### DIFF
--- a/admin/Caddyfile
+++ b/admin/Caddyfile
@@ -1,8 +1,10 @@
 :80 {
-	handle /admin/* {
-		uri strip_prefix /admin
+		# 托管管理后台静态文件
 		root * /usr/share/caddy/admin
 		try_files {path} /index.html
 		file_server
-	}
+	log {
+        output stdout
+        format console
+    }
 }

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <!-- <link href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"> -->
-    <link href="/admin/css/font-awesome.min.css" rel="stylesheet">
+    <link href="css/font-awesome.min.css" rel="stylesheet">
     <title><%= webpackConfig.name %></title>
   </head>
   <body>

--- a/server/Caddyfile
+++ b/server/Caddyfile
@@ -12,9 +12,9 @@
     handle_path /admin/* {
         reverse_proxy server:8360
     }
-
+ # 默认路径转发到管理后台前端
     handle {
-        reverse_proxy server:8360
+       reverse_proxy hioshop-admin:80
     }
 
     log {

--- a/server/Caddyfile
+++ b/server/Caddyfile
@@ -1,10 +1,6 @@
 :80 {
     encode gzip zstd
 
-    handle /static/* {
-        reverse_proxy server:8360
-    }
-
     handle_path /api/* {
         reverse_proxy server:8360
     }
@@ -12,7 +8,8 @@
     handle_path /admin/* {
         reverse_proxy server:8360
     }
- # 默认路径转发到管理后台前端
+
+ # 默认路径转发到管理后台前端（包括/static/*静态资源）
     handle {
        reverse_proxy hioshop-admin:80
     }


### PR DESCRIPTION
### 1. `server/Caddyfile`
默认路径转发到 `hioshop-admin:80` 容器（admin 前端）
### 2. `admin/Caddyfile`
添加 `uri strip_prefix /admin` 路径前缀处理
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Caddy routing to support admin frontend access by changing default proxy target and handling URI prefix.
> 
>   - **Routing Configuration**:
>     - In `server/Caddyfile`, change default reverse proxy target to `hioshop-admin:80` for admin frontend access.
>     - In `admin/Caddyfile`, add `uri strip_prefix /admin` to handle path prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=beisi-tech%2Fhioshop-miniprogram&utm_source=github&utm_medium=referral)<sup> for be233006ca1b3bd6284b526aba793a1717ecb18b. You can [customize](https://app.ellipsis.dev/beisi-tech/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->